### PR TITLE
Add a clang-format config for uniform code formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+AllowShortBlocksOnASingleLine: false
+BasedOnStyle: Google
+InsertBraces: true
+BraceWrapping:
+  AfterFunction: true
+BreakBeforeBraces: Custom
+ColumnLimit: 80
+DerivePointerAlignment: false
+IndentCaseLabels: false
+IndentWidth: 4
+PointerAlignment: Right
+BreakAfterJavaFieldAnnotations: true

--- a/src/PhoenixPositionProvider.cpp
+++ b/src/PhoenixPositionProvider.cpp
@@ -1,34 +1,34 @@
 #include "PhoenixPositionProvider.h"
 
-using std::string;
 using std::stof;
+using std::string;
 
 using std::runtime_error;
 
-using std::endl;
 using std::cout;
+using std::endl;
 
 // TODO
 // - confirm maxDeploymentSpeeds (defined in .h) with Recovery people
 // change coordinate system to right-handed
 // - test!!!
 
-PhoenixPositionProvider::PhoenixPositionProvider() {
-    
+PhoenixPositionProvider::PhoenixPositionProvider()
+{
     // x pos, x vel, y pos, y vel, z pos, z vel
     currentConditions = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-    position = Vector3(0,0,0);
+    position = Vector3(0, 0, 0);
 
     didIgniteFlag = false;
     didChuteFlag = false;
     didDrogueFlag = false;
 
     rocketState = State::PRE_FLIGHT;
-    
 }
 
-void PhoenixPositionProvider::process(double deltaTime){
+void PhoenixPositionProvider::process(double deltaTime)
+{
     cout << "--------------" << endl;
     cout << "current internal time is " << currentTime << endl;
     // do the integration, based on the current stage
@@ -39,17 +39,18 @@ void PhoenixPositionProvider::process(double deltaTime){
 
     } else if (rocketState == State::BURN) {
         cout << "in BURN stage" << endl;
-        
+
         if (ignitionTime + burnTime < currentTime + deltaTime) {
             double step1 = ignitionTime + burnTime - currentTime;
             double step2 = deltaTime - step1;
 
-            cout << "BURN stage: " << currentTime << " -> " << currentTime + step1 << endl;
+            cout << "BURN stage: " << currentTime << " -> "
+                 << currentTime + step1 << endl;
 
             // use DE1 till fuel runs out
-            integrate_const(
-                stepper, createDE1, currentConditions, currentTime, currentTime + step1, dt, push_back_state_and_time(allPositions, times)
-            );
+            integrate_const(stepper, createDE1, currentConditions, currentTime,
+                            currentTime + step1, dt,
+                            push_back_state_and_time(allPositions, times));
 
             currentConditions = allPositions[allPositions.size() - 1];
             cout << "fuel ran out!\n";
@@ -57,43 +58,43 @@ void PhoenixPositionProvider::process(double deltaTime){
             // switch state to COAST
             rocketState = State::COAST;
             cout << "switching state to COAST!\n";
-            cout << "COAST stage: " << currentTime + step1 << " -> " << currentTime + step1 + step2 << endl;
-
+            cout << "COAST stage: " << currentTime + step1 << " -> "
+                 << currentTime + step1 + step2 << endl;
 
             // use DE2, since fuel is run out
-            integrate_const(
-                stepper, createDE2, currentConditions, currentTime + step1, currentTime + step1 + step2, dt, push_back_state_and_time(allPositions, times)
-            );      
+            integrate_const(stepper, createDE2, currentConditions,
+                            currentTime + step1, currentTime + step1 + step2,
+                            dt, push_back_state_and_time(allPositions, times));
         } else {
             // use DE1 (burn stage system of equation)
-            integrate_const(
-                stepper, createDE1, currentConditions, currentTime, currentTime + deltaTime, dt, push_back_state_and_time(allPositions, times)
-            );
+            integrate_const(stepper, createDE1, currentConditions, currentTime,
+                            currentTime + deltaTime, dt,
+                            push_back_state_and_time(allPositions, times));
         }
-        
+
         // update currentConditions for next integration
         currentConditions = allPositions[allPositions.size() - 1];
 
     } else if (rocketState == State::COAST) {
         cout << "in COAST stage" << endl;
-        integrate_const(
-            stepper, createDE2, currentConditions, currentTime, currentTime + deltaTime, dt, push_back_state_and_time(allPositions, times)
-            );
+        integrate_const(stepper, createDE2, currentConditions, currentTime,
+                        currentTime + deltaTime, dt,
+                        push_back_state_and_time(allPositions, times));
         // update currentConditions for next integration
         currentConditions = allPositions[allPositions.size() - 1];
 
     } else if (rocketState == State::DROGUE) {
         cout << "in DROGUE CHUTE stage" << endl;
-        integrate_const(
-            stepper, createDE3, currentConditions, currentTime, currentTime + deltaTime, dt, push_back_state_and_time(allPositions, times)
-            );
+        integrate_const(stepper, createDE3, currentConditions, currentTime,
+                        currentTime + deltaTime, dt,
+                        push_back_state_and_time(allPositions, times));
         // update currentConditions for next integration
         currentConditions = allPositions[allPositions.size() - 1];
     } else if (rocketState == State::CHUTE) {
         cout << "in MAIN CHUTE stage" << endl;
-        integrate_const(
-            stepper, createDE4, currentConditions, currentTime, currentTime + deltaTime, dt, push_back_state_and_time(allPositions, times)
-            );
+        integrate_const(stepper, createDE4, currentConditions, currentTime,
+                        currentTime + deltaTime, dt,
+                        push_back_state_and_time(allPositions, times));
         // update currentConditions for next integration
         currentConditions = allPositions[allPositions.size() - 1];
     }
@@ -103,23 +104,23 @@ void PhoenixPositionProvider::process(double deltaTime){
 
     // update currCoords
     position.x = currentConditions[0];
-    position.y = currentConditions[2]; 
+    position.y = currentConditions[2];
     position.z = currentConditions[4];
-    
+
     readOut();
 
     // terminate program when rocket has crashed
     if (position.y <= 0 && rocketState != State::PRE_FLIGHT) {
         readOut();
-        // TODO: Add rocket state and Y velocity to error message so we can see if it was a crash or landing
-        throw runtime_error("Rocket Y position <= 0. Rocket has landed (hopefully), or crashed.");
+        // TODO: Add rocket state and Y velocity to error message so we can see
+        // if it was a crash or landing
+        throw runtime_error(
+            "Rocket Y position <= 0. Rocket has landed (hopefully), or "
+            "crashed.");
     }
 }
 
-Vector3 PhoenixPositionProvider::getPosition()
-{
-    return this->position;
-}
+Vector3 PhoenixPositionProvider::getPosition() { return this->position; }
 
 PhoenixPositionProvider::State PhoenixPositionProvider::getFlightState()
 {
@@ -129,7 +130,8 @@ PhoenixPositionProvider::State PhoenixPositionProvider::getFlightState()
 void PhoenixPositionProvider::ignite()
 {
     if (didIgniteFlag) {
-        throw runtime_error("Error: PhoenixPositionProvider::ignite() was called twice.");
+        throw runtime_error(
+            "Error: PhoenixPositionProvider::ignite() was called twice.");
     }
     didIgniteFlag = true;
     rocketState = State::BURN;
@@ -138,34 +140,30 @@ void PhoenixPositionProvider::ignite()
     // cout << "ignition time: " << ignitionTime << "\n" << endl;
 }
 
-bool PhoenixPositionProvider::didIgnite()
-{
-    return this->didIgniteFlag;
-}
+bool PhoenixPositionProvider::didIgnite() { return this->didIgniteFlag; }
 
 void PhoenixPositionProvider::drogue()
 {
     if (!didIgniteFlag) {
         throw runtime_error("Error: Drogue deployment before ignition");
     }
-    
+
     if (didDrogueFlag) {
-        throw runtime_error("Error: PhoenixPositionProvider::drogue() was called twice.");
+        throw runtime_error(
+            "Error: PhoenixPositionProvider::drogue() was called twice.");
     }
-    
+
     if (abs(currentConditions[3]) > drogueMaxDeploymentSpeed) {
         readOut();
-        throw runtime_error("Error: Drogue deployment speed was too fast. Chute ripped.");
+        throw runtime_error(
+            "Error: Drogue deployment speed was too fast. Chute ripped.");
     }
     didDrogueFlag = true;
     rocketState = State::DROGUE;
     cout << "------ Drogue Chute Deployment! ------" << endl;
 }
 
-bool PhoenixPositionProvider::didDrogue()
-{
-    return this->didDrogueFlag;
-}
+bool PhoenixPositionProvider::didDrogue() { return this->didDrogueFlag; }
 
 void PhoenixPositionProvider::chute()
 {
@@ -176,31 +174,34 @@ void PhoenixPositionProvider::chute()
         throw runtime_error("Error: Chute deployed before drogue deployment");
     }
     if (didChuteFlag) {
-        throw runtime_error("Error: PhoenixPositionProvider::chute() was called twice.");
+        throw runtime_error(
+            "Error: PhoenixPositionProvider::chute() was called twice.");
     }
-    
+
     if (abs(currentConditions[3]) > chuteMaxDeploymentSpeed) {
         readOut();
-        throw runtime_error("Error: Chute deployment speed was too fast. Chute ripped.");
+        throw runtime_error(
+            "Error: Chute deployment speed was too fast. Chute ripped.");
     }
     didChuteFlag = true;
     rocketState = State::CHUTE;
     cout << "------ Main Chute Deployment! ------" << endl;
 }
 
-bool PhoenixPositionProvider::didChute()
-{
-    return this->didChuteFlag;
-}
+bool PhoenixPositionProvider::didChute() { return this->didChuteFlag; }
 
-stateType PhoenixPositionProvider::getCurrentConditions() {
+stateType PhoenixPositionProvider::getCurrentConditions()
+{
     return currentConditions;
 }
 
-void PhoenixPositionProvider::readOut() {
-    cout << "[Rocket Telemetry]\n" 
-        << "x_pos: " << currentConditions[0] << ", x_vel: " << currentConditions[1]
-        << "\ny_pos: " << currentConditions[2] << ", y_vel: " << currentConditions[3]
-        << "\nz_pos: " << currentConditions[4] << ", z_vel: " << currentConditions[5] 
-        << endl;
+void PhoenixPositionProvider::readOut()
+{
+    cout << "[Rocket Telemetry]\n"
+         << "x_pos: " << currentConditions[0]
+         << ", x_vel: " << currentConditions[1]
+         << "\ny_pos: " << currentConditions[2]
+         << ", y_vel: " << currentConditions[3]
+         << "\nz_pos: " << currentConditions[4]
+         << ", z_vel: " << currentConditions[5] << endl;
 }

--- a/src/PhoenixPositionProvider.h
+++ b/src/PhoenixPositionProvider.h
@@ -1,65 +1,58 @@
 #ifndef PHOENIX_POSITION_PROVIDER_H
 #define PHOENIX_POSITION_PROVIDER_H
-#include <time.h> // for seeind rand
-#include <stdlib.h> // for rand
+#include <stdlib.h>  // for rand
+#include <time.h>    // for seeind rand
+
 #include "PhoenixPositionProviderUtility.h"
 #include "Vector3.hpp"
 
 using namespace boost::numeric::odeint;
 
 // asked recovery, they said 100ft/s (seems kinda slow but ig)
-const float drogueMaxDeploymentSpeed = 30.48; // m/s, ask recovery people about this
-const float chuteMaxDeploymentSpeed = 30.48; // and this
+const float drogueMaxDeploymentSpeed =
+    30.48;  // m/s, ask recovery people about this
+const float chuteMaxDeploymentSpeed = 30.48;  // and this
 
+class PhoenixPositionProvider {
+   public:
+    enum class State { PRE_FLIGHT, BURN, COAST, DROGUE, CHUTE };
 
-class PhoenixPositionProvider
-{
-    public:
-        enum class State {
-            PRE_FLIGHT,
-            BURN,
-            COAST,
-            DROGUE,
-            CHUTE
-        };
+   private:
+    const double dt = 0.01;  // must be a double for odeint to work
 
-    private:
-        const double dt = 0.01; // must be a double for odeint to work
+    // x, y, z position
+    Vector3 position;
 
-        // x, y, z position
-        Vector3 position;
-        
-        double ignitionTime;
-        runge_kutta4<stateType> stepper;
-        stateType currentConditions;
-        std::vector<stateType> allPositions;
-        std::vector<double> times;
-        double currentTime;
-        State rocketState;
-        
-        bool didIgniteFlag;
-        bool didChuteFlag;
-        bool didDrogueFlag;
+    double ignitionTime;
+    runge_kutta4<stateType> stepper;
+    stateType currentConditions;
+    std::vector<stateType> allPositions;
+    std::vector<double> times;
+    double currentTime;
+    State rocketState;
 
-    public:
-        
-        PhoenixPositionProvider();
+    bool didIgniteFlag;
+    bool didChuteFlag;
+    bool didDrogueFlag;
 
-        void process(double deltaTime);
-        Vector3 getPosition();
-        void ignite();
-        void drogue();
-        void chute();
+   public:
+    PhoenixPositionProvider();
 
-        bool didIgnite(); // Returns true if ignite() was called once, false otherwise.
-                          // Pretty much used only for testing.
-        bool didChute();
-        bool didDrogue();
+    void process(double deltaTime);
+    Vector3 getPosition();
+    void ignite();
+    void drogue();
+    void chute();
 
-        State getFlightState();
-        stateType getCurrentConditions();
+    bool didIgnite();  // Returns true if ignite() was called once, false
+                       // otherwise. Pretty much used only for testing.
+    bool didChute();
+    bool didDrogue();
 
-        void readOut();
+    State getFlightState();
+    stateType getCurrentConditions();
+
+    void readOut();
 };
 
 #endif

--- a/src/PhoenixPositionProviderUtility.cpp
+++ b/src/PhoenixPositionProviderUtility.cpp
@@ -1,24 +1,26 @@
-# include "PhoenixPositionProviderUtility.h"
+#include "PhoenixPositionProviderUtility.h"
 
-using std::vector;
 using std::string;
+using std::vector;
 
 using std::endl;
 
-//the first row of atmosisa csv file is T, second is a, third is P, fourth is rho
+// the first row of atmosisa csv file is T, second is a, third is P, fourth is
+// rho
 
-vector<vector<float>> parseFile(const string& filename){
-    vector<vector<float>> result; // Vector to store the final result
+vector<vector<float>> parseFile(const string &filename)
+{
+    vector<vector<float>> result;  // Vector to store the final result
 
     std::ifstream atmos_file(filename);
     if (!atmos_file.is_open()) {
         std::cerr << "Error: Unable to open file " << filename << endl;
-        return result; // Return an empty vector if the file cannot be opened
+        return result;  // Return an empty vector if the file cannot be opened
     }
 
     string line;
     while (std::getline(atmos_file, line)) {
-        vector<float> row; // Vector to store the values of a single row
+        vector<float> row;  // Vector to store the values of a single row
 
         std::istringstream iss(line);
         string value;
@@ -27,7 +29,7 @@ vector<vector<float>> parseFile(const string& filename){
             row.push_back(floatValue);
         }
 
-        result.push_back(row); // Add the row to the final result
+        result.push_back(row);  // Add the row to the final result
     }
 
     atmos_file.close();
@@ -41,7 +43,8 @@ vector<float> speed_of_sound = atmos_data[1];
 vector<float> pressure = atmos_data[2];
 vector<float> rho = atmos_data[3];
 
-float linearInterp(float x, vector<float> all_x, vector<float> all_y) {
+float linearInterp(float x, vector<float> all_x, vector<float> all_y)
+{
     if (all_x[0] == x) {
         return all_y[0];
     } else if (all_x[0] < x) {
@@ -55,7 +58,8 @@ float linearInterp(float x, vector<float> all_x, vector<float> all_y) {
         float y2 = all_y[pos];
         float slope = (y2 - y1) / (x2 - x1);
         return y1 + (x - x1) * slope;
-    } else { // if we are extrapolating behind all_x (only consider behind because we never extrapolate over)
+    } else {  // if we are extrapolating behind all_x (only consider behind
+              // because we never extrapolate over)
         float x1 = all_x[1];
         float x2 = all_x[0];
         float y1 = all_y[1];
@@ -65,28 +69,30 @@ float linearInterp(float x, vector<float> all_x, vector<float> all_y) {
     }
 }
 
-//put airDensityFromAltitude function here
-vector<float> getAltitudes(){
+// put airDensityFromAltitude function here
+vector<float> getAltitudes()
+{
     vector<float> toReturn;
-    for(int i = 0; i < 10001; i++){
-        toReturn.push_back(float(i)); 
+    for (int i = 0; i < 10001; i++) {
+        toReturn.push_back(float(i));
     }
     return toReturn;
 }
 
 vector<float> altitudes = getAltitudes();
 
-float AirDensityFromAltitude(float x){ // looks correct
+float AirDensityFromAltitude(float x)
+{  // looks correct
     return linearInterp(x, altitudes, rho);
 }
 
-
 // put mach and drag stuff here
 
-vector<float> convert_to_ms(vector<float> mach_data){
+vector<float> convert_to_ms(vector<float> mach_data)
+{
     vector<float> toReturn;
-    for(float num: mach_data){
-        num = num*343;
+    for (float num : mach_data) {
+        num = num * 343;
         toReturn.push_back(num);
     }
     // cout << toReturn[0] << endl;
@@ -102,18 +108,18 @@ vector<vector<float>> thrust_curve = parseFile("thrust_curve.csv");
 vector<float> height = thrust_curve[0];
 vector<float> thrust = thrust_curve[1];
 
-
-float mass(float t) {
-    return DryMass + FuelMass - m_dot * t;
-}
+float mass(float t) { return DryMass + FuelMass - m_dot * t; }
 // calculate the mass of rocket at time t
 
-float TempWindLoad(float y) {
-    int WindOffset = (rand() % 7) - 3; // force range to [-3, 3]
-    return 0.5 * AirDensityFromAltitude(y) * pow((AvgWindSpeed + WindOffset), 2) * Rocket_WindloadArea;
+float TempWindLoad(float y)
+{
+    int WindOffset = (rand() % 7) - 3;  // force range to [-3, 3]
+    return 0.5 * AirDensityFromAltitude(y) *
+           pow((AvgWindSpeed + WindOffset), 2) * Rocket_WindloadArea;
 }
 
-vector<float> GenerateWindLoadData() {
+vector<float> GenerateWindLoadData()
+{
     vector<float> windloads;
     for (int alt = 0; alt < 10001; alt++) {
         float offset = -1 + 2 * (rand() / static_cast<double>(RAND_MAX));
@@ -126,57 +132,68 @@ vector<float> GenerateWindLoadData() {
 vector<float> windloads_x = GenerateWindLoadData();
 vector<float> windloads_z = GenerateWindLoadData();
 
-float WindLoad_x(float y) {
+float WindLoad_x(float y)
+{
     // cout << "abc" << endl;
     float a = linearInterp(y, altitudes, windloads_x);
     // cout << "zxy" << endl;
     return a;
 }
 
-float WindLoad_z(float y) {
+float WindLoad_z(float y)
+{
     // cout << "abc" << endl;
     float a = linearInterp(y, altitudes, windloads_z);
     // cout << "zxy" << endl;
     return a;
 }
 
-float Thrust(float y) { // looks correct
+float Thrust(float y)
+{  // looks correct
     return linearInterp(y, height, thrust);
 }
 
-float RocketCd(float vy) { // looks good
+float RocketCd(float vy)
+{  // looks good
     return linearInterp(vy, mach_num, drag_coef);
 }
 
-
-float RocketDrag(float y, float vy) { // looks good
-    return 0.5 * AirDensityFromAltitude(y) * pow(vy, 2) * RocketCd(vy) * Rocket_Cross_Section_Area;
+float RocketDrag(float y, float vy)
+{  // looks good
+    return 0.5 * AirDensityFromAltitude(y) * pow(vy, 2) * RocketCd(vy) *
+           Rocket_Cross_Section_Area;
 }
 
-float DrogueDrag(float y, float vy) {
-    return 0.5 * AirDensityFromAltitude(y) * pow(vy, 2) * DrogueCd * Drogue_Area; 
+float DrogueDrag(float y, float vy)
+{
+    return 0.5 * AirDensityFromAltitude(y) * pow(vy, 2) * DrogueCd *
+           Drogue_Area;
 }
 
-float MainDrag(float y, float vy) {
-    return 0.5 * AirDensityFromAltitude(y) * pow(vy, 2) * MainCd * Main_Area; 
+float MainDrag(float y, float vy)
+{
+    return 0.5 * AirDensityFromAltitude(y) * pow(vy, 2) * MainCd * Main_Area;
 }
 
 // stateType = {x pos, x vel, y pos, y vel, z pos, z vel}
 
 // DE1 works!
-void createDE1(const stateType& q, stateType& dqdt, const double t) {
+void createDE1(const stateType &q, stateType &dqdt, const double t)
+{
     // cout << "Stage 1: Lift off, Engine in operation..." << endl;
     dqdt[0] = q[1];
     dqdt[1] = 1.0 / mass(t) * WindLoad_x(q[2]);
     dqdt[2] = q[3];
-    dqdt[3] = 1.0 / mass(t) * (Thrust(q[2]) - mass(t) * g - RocketDrag(q[2], q[3]));
+    dqdt[3] =
+        1.0 / mass(t) * (Thrust(q[2]) - mass(t) * g - RocketDrag(q[2], q[3]));
     dqdt[4] = q[5];
     dqdt[5] = 1.0 / mass(t) * WindLoad_z(q[2]);
 }
 
 //
-void createDE2(const stateType& q, stateType& dqdt, const double t) {
-    //cout << "Stage 2: Engine turns off, continuing upward..." << endl;
+void createDE2(const stateType &q, stateType &dqdt, const double t)
+{
+    // cout << "Stage 2: Engine turns off, continuing upward..." << endl;
     dqdt[0] = q[1];
     dqdt[1] = 1.0 / DryMass * WindLoad_x(q[2]);
     dqdt[2] = q[3];
@@ -185,31 +202,39 @@ void createDE2(const stateType& q, stateType& dqdt, const double t) {
     dqdt[5] = 1.0 / DryMass * WindLoad_z(q[2]);
 }
 
-void createDE3(const stateType& q, stateType& dqdt, const double t) {
-    //cout << "Stage 3: Drogue parachute deploys at Apogee..." << endl;
+void createDE3(const stateType &q, stateType &dqdt, const double t)
+{
+    // cout << "Stage 3: Drogue parachute deploys at Apogee..." << endl;
     dqdt[0] = q[1];
     dqdt[1] = 1.0 / DryMass * WindLoad_x(q[2]);
     dqdt[2] = q[3];
-    dqdt[3] = 1.0 / DryMass * (RocketDrag(q[2], abs(q[3])) + DrogueDrag(q[2], abs(q[3])) - DryMass*g);
+    dqdt[3] = 1.0 / DryMass *
+              (RocketDrag(q[2], abs(q[3])) + DrogueDrag(q[2], abs(q[3])) -
+               DryMass * g);
     dqdt[4] = q[5];
     dqdt[5] = 1.0 / DryMass * WindLoad_z(q[2]);
 }
 
-void createDE4(const stateType& q, stateType& dqdt, const double t) {
-    //cout << "Stage 4: Main parachute deploys..." <<endl;
+void createDE4(const stateType &q, stateType &dqdt, const double t)
+{
+    // cout << "Stage 4: Main parachute deploys..." <<endl;
     dqdt[0] = q[1];
     dqdt[1] = 1.0 / DryMass * WindLoad_x(q[2]);
     dqdt[2] = q[3];
-    dqdt[3] = 1.0 / DryMass * (RocketDrag(q[2], abs(q[3])) + MainDrag(q[2], abs(q[3])) - DryMass*g);
+    dqdt[3] =
+        1.0 / DryMass *
+        (RocketDrag(q[2], abs(q[3])) + MainDrag(q[2], abs(q[3])) - DryMass * g);
     dqdt[4] = q[5];
     dqdt[5] = 1.0 / DryMass * WindLoad_z(q[2]);
 }
 
-push_back_state_and_time::push_back_state_and_time(vector<stateType>& states, vector<double>& times)
-    : m_states(states), m_times(times) {}
+push_back_state_and_time::push_back_state_and_time(vector<stateType> &states,
+                                                   vector<double> &times)
+    : m_states(states), m_times(times)
+{
+}
 
-
-void push_back_state_and_time::operator()(const stateType& x, double t)
+void push_back_state_and_time::operator()(const stateType &x, double t)
 {
     m_states.push_back(x);
     m_times.push_back(t);

--- a/src/PhoenixPositionProviderUtility.h
+++ b/src/PhoenixPositionProviderUtility.h
@@ -1,27 +1,25 @@
 #ifndef PHOENIX_POSITION_PROVIDER_UTILITY_H
 #define PHOENIX_POSITION_PROVIDER_UTILITY_H
 #include <boost/numeric/odeint.hpp>
-#include "spline.h"
 #include <cmath>
-#include <vector>
-#include <sstream>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
 
+#include "spline.h"
 
 #define PI boost::math::constants::pi<double>()
 
-
 // CONSTANTS
 
-const float g = 9.81; // m/s
-
+const float g = 9.81;  // m/s
 
 // rocket body parameters
-const float DryMass = 54.4218; //kg  (126 lbs)
-const float FuelMass = 20.72917; //kg  (45.7 lbs)
-const float Rocket_Diameter = 0.206756; //m  (8.14 in)
-const float Rocket_Height = 4.64; //m (165 in)
+const float DryMass = 54.4218;           // kg  (126 lbs)
+const float FuelMass = 20.72917;         // kg  (45.7 lbs)
+const float Rocket_Diameter = 0.206756;  // m  (8.14 in)
+const float Rocket_Height = 4.64;        // m (165 in)
 const float Rocket_WindloadArea = Rocket_Diameter * Rocket_Height;
 const float Rocket_Cross_Section_Area = PI * pow(Rocket_Diameter / 2, 2);
 
@@ -36,12 +34,12 @@ const float Main_Diameter = 4.8768;
 const float Main_Area = PI * pow(Main_Diameter / 2, 2);
 
 // rocket fuel parameters
-const float m_dot = 1.2579; // kg/s, mass flow rate of fuel
-const double burnTime = 16.48; //FuelMass / m_dot ~= 16.479 seconds, rounded to make math cleaner
+const float m_dot = 1.2579;  // kg/s, mass flow rate of fuel
+const double burnTime =
+    16.48;  // FuelMass / m_dot ~= 16.479 seconds, rounded to make math cleaner
 
 // wind parameters
-const float AvgWindSpeed = 10; // m/s, average speed of wind of FAR site
-
+const float AvgWindSpeed = 10;  // m/s, average speed of wind of FAR site
 
 // FUNCTION DECLARATIONS
 
@@ -55,29 +53,26 @@ float RocketCd(float vy);
 float RocketDrag(float y, float vy);
 float DrogueDrag(float y, float vy);
 float MainDrag(float y, float vy);
-std::vector<std::vector<float>> parseFile(const std::string& filename);
+std::vector<std::vector<float>> parseFile(const std::string &filename);
 std::vector<float> getAltitudes();
 float linearInterp(float x, std::vector<float> all_x, std::vector<float> all_y);
 float splineInterp(float x, std::vector<float> all_x, std::vector<float> all_y);
 float AirDensityFromAltitude(float x);
 
-
 typedef boost::array<double, 6> stateType;
 
+void createDE1(const stateType &q, stateType &dqdt, const double t);
+void createDE2(const stateType &q, stateType &dqdt, const double t);
+void createDE3(const stateType &q, stateType &dqdt, const double t);
+void createDE4(const stateType &q, stateType &dqdt, const double t);
 
+struct push_back_state_and_time {
+    std::vector<stateType> &m_states;
+    std::vector<double> &m_times;
 
-void createDE1(const stateType& q, stateType& dqdt, const double t);
-void createDE2(const stateType& q, stateType& dqdt, const double t);
-void createDE3(const stateType& q, stateType& dqdt, const double t);
-void createDE4(const stateType& q, stateType& dqdt, const double t);
-
-struct push_back_state_and_time
-{
-    std::vector<stateType>& m_states;
-    std::vector<double>& m_times;
-
-    push_back_state_and_time(std::vector<stateType>& states, std::vector<double>& times);
-    void operator()(const stateType& x, double t);
+    push_back_state_and_time(std::vector<stateType> &states,
+                             std::vector<double> &times);
+    void operator()(const stateType &x, double t);
 };
 
 #endif

--- a/src/SimParams.hpp
+++ b/src/SimParams.hpp
@@ -1,51 +1,45 @@
 #ifndef SIMPARAMS_H
 #define SIMPARAMS_H
 
-#include "exitCodeDefines.hpp"
-
+#include <boost/program_options.hpp>
 #include <iostream>
 #include <string>
 
-#include <boost/program_options.hpp>
+#include "exitCodeDefines.hpp"
 namespace po = boost::program_options;
 
-
 // A struct used by parse_command_line_arguments to return a lot of information.
-struct CliParseResult
-{
-    int exit_code;        // Exit code. 0 is okay, everything else is an error.
-    po::variables_map vm; // Map of named variables
+struct CliParseResult {
+    int exit_code;         // Exit code. 0 is okay, everything else is an error.
+    po::variables_map vm;  // Map of named variables
 };
 
 // A struct containing decoded command line arguments
 // and some inputs parsed from files.
-struct SimParams
-{
+struct SimParams {
     std::string init_state_path;
     std::string output_path;
 };
 
-struct ParseSimParamsResult
-{
+struct ParseSimParamsResult {
     int exit_code;         // Exit code. 0 is okay, everything else is an error.
     SimParams sim_params;  // Read parameters
 };
-
 
 // Creates the options object
 po::options_description get_options_description()
 {
     po::options_description options("Arguments");
-    options.add_options()
-        ("help,h", "Displays the help message")
-        ("init-state,i", po::value<std::string>()->required(), "path of initial state configuration file")
-        ("output,o", po::value<std::string>()->required(), "path of simulator output file")
-    ;
+    options.add_options()("help,h", "Displays the help message")(
+        "init-state,i", po::value<std::string>()->required(),
+        "path of initial state configuration file")(
+        "output,o", po::value<std::string>()->required(),
+        "path of simulator output file");
 
     return options;
 }
 
-// JUST parses command line arguments. 
+// JUST parses command line arguments.
 CliParseResult parse_command_line_arguments(int argC, char *argV[])
 {
     // Initialize result
@@ -55,32 +49,34 @@ CliParseResult parse_command_line_arguments(int argC, char *argV[])
     // Get description
     po::options_description options = get_options_description();
 
-    // Before running notify (which throws exceptions if the program option requirements are not met)
-    // check if we parsed 'help.' If so, exit early and display the help message.
-    po::store(po::parse_command_line(argC, argV, options), result.vm); // Store performs a best-effort parse without throwing exceptions
+    // Before running notify (which throws exceptions if the program option
+    // requirements are not met) check if we parsed 'help.' If so, exit early
+    // and display the help message.
+    po::store(po::parse_command_line(argC, argV, options),
+              result.vm);  // Store performs a best-effort parse without
+                           // throwing exceptions
     if (result.vm.count("help")) {
-        
-        std::cout << options << "\n"; // TODO: Consider decoupling output logic from parsing logic.
-        
+        std::cout << options << "\n";  // TODO: Consider decoupling output logic
+                                       // from parsing logic.
+
         result.exit_code = EXIT_CODE_DISPLAYED_HELP;
         return result;
     }
 
     // Try parsing command line arguments.
-    try
-    {
+    try {
         po::notify(result.vm);
-    }
-    catch(std::exception& e)
-    {
-        std::cerr << " Error:" << e.what() << std::endl; // TODO: Consider decoupling output logic from parsing logic.
-        
+    } catch (std::exception &e) {
+        std::cerr << " Error:" << e.what()
+                  << std::endl;  // TODO: Consider decoupling output logic from
+                                 // parsing logic.
+
         result.exit_code = EXIT_CODE_LINE_ARGUMENT_ERROR;
         return result;
-    }
-    catch(...)
-    {
-        std::cerr << "Unknown CLI error!" << std::endl; // TODO: Consider decoupling output logic from parsing logic.
+    } catch (...) {
+        std::cerr << "Unknown CLI error!"
+                  << std::endl;  // TODO: Consider decoupling output logic from
+                                 // parsing logic.
 
         result.exit_code = EXIT_CODE_LINE_ARGUMENT_ERROR;
         return result;
@@ -92,13 +88,15 @@ CliParseResult parse_command_line_arguments(int argC, char *argV[])
     return result;
 }
 
-// Parses command line arguments and populates the given SimParams struct with the command
+// Parses command line arguments and populates the given SimParams struct with
+// the command line arguments.
+//
+// argC and argV are the values passed into main regarding the available command
 // line arguments.
 //
-// argC and argV are the values passed into main regarding the available command line arguments.
-//
-// Returns an integer exit code. If 0, the arguments were parsed correctly and the SimParams struct has
-// valid data. If any exit code other than zero, the SimParams were not populated and the program should exit.
+// Returns an integer exit code. If 0, the arguments were parsed correctly and
+// the SimParams struct has valid data. If any exit code other than zero, the
+// SimParams were not populated and the program should exit.
 
 ParseSimParamsResult get_params(int argC, char *argV[])
 {
@@ -106,13 +104,18 @@ ParseSimParamsResult get_params(int argC, char *argV[])
 
     // Attempt to parse command line arguments
     CliParseResult cli_parse_result = parse_command_line_arguments(argC, argV);
-    result.exit_code = cli_parse_result.exit_code; // Exit early if 
-    if (result.exit_code != EXIT_CODE_OK) { return result; }
+    result.exit_code = cli_parse_result.exit_code;  // Exit early if
+    if (result.exit_code != EXIT_CODE_OK) {
+        return result;
+    }
 
+    if (result.vm.count("output-file")) {
+        result.sim_params.output_path =
+            result.vm["output-file"].as<std::string>();
+    }
     // TODO load and parse JSON, configs...
 
     return result;
 }
-
 
 #endif /* SIMPARAMS_H */

--- a/src/Vector3.hpp
+++ b/src/Vector3.hpp
@@ -1,45 +1,31 @@
 #ifndef VECTOR3_H
 #define VECTOR3_H
 
-struct Vector3
-{
-    private:
+struct Vector3 {
+   private:
+   public:
+    double x;
+    double y;
+    double z;
 
-    public:
-        double x;
-        double y;
-        double z;
+    Vector3();
+    Vector3(double x, double y, double z);
 
-        Vector3();
-        Vector3(double x, double y, double z);
+    // Operators
+    Vector3 operator+(const Vector3 &rhs) const
+    {
+        return Vector3(this->x + rhs.x, this->y + rhs.y, this->z + rhs.z);
+    }
 
-        // Operators
-        Vector3 operator+(const Vector3& rhs) const
-        {
-            return Vector3(
-                this->x + rhs.x,
-                this->y + rhs.y,
-                this->z + rhs.z
-            );
-        }
+    Vector3 operator-(const Vector3 &rhs) const
+    {
+        return Vector3(this->x - rhs.x, this->y - rhs.y, this->z - rhs.z);
+    }
 
-        Vector3 operator-(const Vector3& rhs) const
-        {
-            return Vector3(
-                this->x - rhs.x,
-                this->y - rhs.y,
-                this->z - rhs.z
-            );
-        }
-
-        Vector3 operator*(double scalar) const 
-        {
-            return Vector3(
-                this->x * scalar,
-                this->y * scalar,
-                this->z * scalar
-            );
-        }
+    Vector3 operator*(double scalar) const
+    {
+        return Vector3(this->x * scalar, this->y * scalar, this->z * scalar);
+    }
 };
 
 #endif /* VECTOR3_H */

--- a/src/exitCodeDefines.hpp
+++ b/src/exitCodeDefines.hpp
@@ -2,8 +2,10 @@
 #define ERROR_CODE_DEFINES_H
 
 #define EXIT_CODE_OK 0
-#define EXIT_CODE_DISPLAYED_HELP 1      // Returned when --help or -h is provided as an argument. 
-                                        // Help was displayed, simulator did not run.
-#define EXIT_CODE_LINE_ARGUMENT_ERROR 2 // For incorrect command line arguments.
+#define EXIT_CODE_DISPLAYED_HELP \
+    1  // Returned when --help or -h is provided as an argument.
+       // Help was displayed, simulator did not run.
+#define EXIT_CODE_LINE_ARGUMENT_ERROR \
+    2  // For incorrect command line arguments.
 
 #endif /* ERROR_CODE_DEFINES_H */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,14 @@
 
-#include "exitCodeDefines.hpp"
-
 #include "SimParams.hpp"
-
+#include "exitCodeDefines.hpp"
 
 int main(int ac, char *av[])
 {
-
     ParseSimParamsResult result = get_params(ac, av);
 
-    if (result.exit_code != EXIT_CODE_OK) { return result.exit_code; }
+    if (result.exit_code != EXIT_CODE_OK) {
+        return result.exit_code;
+    }
 
     return EXIT_CODE_OK;
 }
-
-


### PR DESCRIPTION
It's generally desirable to have a consistently formatted codebase for readability. This PR adds a configuration for `clang-format`, which is the industry standard for C++ formatting, and formats everything in the `src/` folder.